### PR TITLE
implement optional inactive titlebar color

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Activate by using command 'Color This Top Bar'. Or go to settings and turn on 'A
     * `titleBar.activeBackground`
     * `titleBar.activeForeground`
     * `titleBar.inactiveBackground`
+    * `titleBar.inactiveForeground`
 
 ## Release Notes
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Activate by using command 'Color This Top Bar'. Or go to settings and turn on 'A
 * Option to automatically colorize instances on start.
 * Does not override existing color settings.
 
+## Troubleshooting / FAQ
+* Colorization was skipped on a project I'd like to colorize.
+  * Colorization will be skipped if any of the following settings are set in the project's `settings.json`. Delete or comment out the entries and reload the window to make the colorization apply. 
+    * `titleBar.activeBackground`
+    * `titleBar.activeForeground`
+    * `titleBar.inactiveBackground`
+
 ## Release Notes
 
 ### 0.0.1

--- a/package.json
+++ b/package.json
@@ -34,6 +34,11 @@
             "description": "Colorize title bars automatically when any new vscode instance is started.",
             "type": "boolean",
             "default": false
+          },
+          "vscode-color-them-top-bars.setInactiveBackground": {
+            "description": "Colorize inactive title bars.",
+            "type": "boolean",
+            "default": false
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/jmathew/vscode-color-them-top-bars"
   },
-  "version": "0.0.2",
+  "version": "0.0.3",
   "engines": {
     "vscode": "^1.74.0"
   },
@@ -35,10 +35,10 @@
             "type": "boolean",
             "default": false
           },
-          "vscode-color-them-top-bars.setInactiveBackground": {
+          "vscode-color-them-top-bars.setInactive": {
             "description": "Colorize inactive title bars.",
             "type": "boolean",
-            "default": false
+            "default": true
           }
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,12 +47,20 @@ async function colorizeTitleBar() {
   const background = stringToColor(vscode.workspace.name);
   const foreground = invertColor(background, true);
 
+  var colorSettings : any = {
+    "titleBar.activeBackground": background,
+    "titleBar.activeForeground": foreground,
+  };
+  const extensionSettings = vscode.workspace.getConfiguration('vscode-color-them-top-bars');
+  if (extensionSettings.get('setInactiveBackground')) {
+    colorSettings["titleBar.inactiveBackground"] = background;
+  }
+
   await settings.update(
     colorCustomizationsSection,
     {
       ...existing,
-      "titleBar.activeBackground": background,
-      "titleBar.activeForeground": foreground,
+      ...colorSettings,
     },
     vscode.ConfigurationTarget.Workspace
   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,6 +39,8 @@ async function colorizeTitleBar() {
   if (
     existing["titleBar.activeBackground"] !== undefined
     || existing["titleBar.activeForeground"] !== undefined
+    || existing["titleBar.inactiveBackground"] !== undefined
+    || existing["titleBar.inactiveForeground"] !== undefined
   ) {
     vscode.window.showInformationMessage('Existing settings found for \'titleBar\', colorization was not applied!');
     return;
@@ -47,13 +49,14 @@ async function colorizeTitleBar() {
   const background = stringToColor(vscode.workspace.name);
   const foreground = invertColor(background, true);
 
-  var colorSettings : any = {
+  var colorSettings: Record<string, any> = {
     "titleBar.activeBackground": background,
     "titleBar.activeForeground": foreground,
   };
   const extensionSettings = vscode.workspace.getConfiguration('vscode-color-them-top-bars');
-  if (extensionSettings.get('setInactiveBackground')) {
+  if (extensionSettings.get('setInactive')) {
     colorSettings["titleBar.inactiveBackground"] = background;
+    colorSettings["titleBar.inactiveForeground"] = foreground;
   }
 
   await settings.update(


### PR DESCRIPTION
Hello,

Thanks for your extension, it's interesting to identify an instance from its color - but also I'd like to identify an inactive window (from task switcher for eg) so I've done this small PR to enable changing inactive titlebar color as well.

A new flag (`setInactiveBackground`) has been introduced to keep compatibility and current behavior. If you prefer to force this new behavior let me know, I will edit this PR accordingly.

NOTE: package version has not been changed.

You will find below screenshots for UI changes.
Thanks.

<img width="638" alt="image" src="https://github.com/jmathew/vscode-color-them-top-bars/assets/1562400/d0970939-90eb-4884-86e2-e3cf4d4a0741">

<img width="523" alt="image" src="https://github.com/jmathew/vscode-color-them-top-bars/assets/1562400/98fb7682-1afc-4119-a5cf-08ead03eb824">
